### PR TITLE
Fix permissions for render on JF and on Emby using linuxserver containers

### DIFF
--- a/apps/emby.yml
+++ b/apps/emby.yml
@@ -17,7 +17,7 @@
         extport: '8096'
         intport2: '8920'
         extport2: '8920'
-        image: 'linuxserver/emby'
+        image: 'linuxserver/emby:beta'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/emby.yml
+++ b/apps/emby.yml
@@ -55,9 +55,8 @@
     - name: 'Setting {{pgrole}} ENV'
       set_fact:
         pg_env:
-          UID: '1000'
-          GID: '1000'
-          GIDLIST: '1000'
+          PUID: '1000'
+          PGID: '1000'
           NVIDIA_VISIBLE_DEVICES: 'all'
           NVIDIA_DRIVER_CAPABILITIES: 'compute,video,utility'
 

--- a/apps/emby.yml
+++ b/apps/emby.yml
@@ -17,7 +17,7 @@
         extport: '8096'
         intport2: '8920'
         extport2: '8920'
-        image: 'linuxserver/emby:beta'
+        image: 'linuxserver/emby'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/emby.yml
+++ b/apps/emby.yml
@@ -17,7 +17,7 @@
         extport: '8096'
         intport2: '8920'
         extport2: '8920'
-        image: 'emby/embyserver'
+        image: 'linuxserver/emby'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/jellyfin.yml
+++ b/apps/jellyfin.yml
@@ -69,7 +69,6 @@
         name: '{{pgrole}}'
         image: '{{image}}'
         pull: yes
-        user: 1000:1000
         published_ports:
           - '{{ports.stdout}}{{extport}}:{{intport}}'
         devices: "{{ '/dev/dri:/dev/dri' if dev_dri.stat.exists == True | default(false) else omit }}"

--- a/apps/jellyfin.yml
+++ b/apps/jellyfin.yml
@@ -15,7 +15,7 @@
         pgrole: 'jellyfin'
         intport: '8096'
         extport: '9096'
-        image: 'jellyfin/jellyfin:latest'
+        image: 'linuxserver/jellyfin:nightly'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
the containers set is from the orignal authors, and it's not optimized for the render, as i have experienced i get issues when i try to HW Transcode things over JF(JellyFin and Emby) so i do this PR for upgrading to linuxserver containers, the permissions allow the render (iGPU) to do HW transcoding 
as expected.
![image](https://user-images.githubusercontent.com/60718477/75294934-e2c9c980-5829-11ea-83bd-366ec111c021.png)


Kind Regards