### PR TITLE
Revert "Fix permissions for render on JF and on Emby using linuxserver containers"

### DIFF
--- a/apps/emby.yml
+++ b/apps/emby.yml
@@ -17,7 +17,7 @@
         extport: '8096'
         intport2: '8920'
         extport2: '8920'
-        image: 'linuxserver/emby'
+        image: 'emby/embyserver'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'
@@ -55,8 +55,9 @@
     - name: 'Setting {{pgrole}} ENV'
       set_fact:
         pg_env:
-          PUID: '1000'
-          PGID: '1000'
+          UID: '1000'
+          GID: '1000'
+          GIDLIST: '1000'
           NVIDIA_VISIBLE_DEVICES: 'all'
           NVIDIA_DRIVER_CAPABILITIES: 'compute,video,utility'
 

--- a/apps/jellyfin.yml
+++ b/apps/jellyfin.yml
@@ -15,7 +15,7 @@
         pgrole: 'jellyfin'
         intport: '8096'
         extport: '9096'
-        image: 'linuxserver/jellyfin:nightly'
+        image: 'jellyfin/jellyfin:latest'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'
@@ -69,6 +69,7 @@
         name: '{{pgrole}}'
         image: '{{image}}'
         pull: yes
+        user: 1000:1000
         published_ports:
           - '{{ports.stdout}}{{extport}}:{{intport}}'
         devices: "{{ '/dev/dri:/dev/dri' if dev_dri.stat.exists == True | default(false) else omit }}"


### PR DESCRIPTION
Reverts MHA-Team/Apps-Core#1 advised that fix is in stable release and as such reverting back to stable.